### PR TITLE
Change -l to -o

### DIFF
--- a/templates/upload_npkfile.sh.tpl
+++ b/templates/upload_npkfile.sh.tpl
@@ -34,7 +34,7 @@ echo "Processing $1 $FILENAME"
 ARCHIVE=$(echo $${FILENAME%.*}).7z
 echo "- Counting lines"
 FILELINES=$(wc -l $2 | cut -d" " -f1)
-SIZE=$(ls -al $2 | cut -d" " -f5)
+SIZE=$(ls -ao $2 | cut -d" " -f4)
 echo "- Compressing"
 7z a $ARCHIVE $2
 


### PR DESCRIPTION
This prevents `ls` from returning user group information. This helps avoid edge cases when the owner group has a space in it (for example `domain users` on an AD joined linux instance)